### PR TITLE
Avoid Cleartext HTTP traffic not permitted on Android P

### DIFF
--- a/app/src/main/java/com/skydoves/themovies/api/Api.kt
+++ b/app/src/main/java/com/skydoves/themovies/api/Api.kt
@@ -6,10 +6,10 @@ package com.skydoves.themovies.api
  */
 
 object Api {
-    private const val BASE_POSTER_PATH = "http://image.tmdb.org/t/p/w342"
-    private const val BASE_BACKDROP_PATH = "http://image.tmdb.org/t/p/w780"
-    private const val YOUTUBE_VIDEO_URL = "http://www.youtube.com/watch?v="
-    private const val YOUTUBE_THUMBNAIL_URL = "http://img.youtube.com/vi/"
+    private const val BASE_POSTER_PATH = "https://image.tmdb.org/t/p/w342"
+    private const val BASE_BACKDROP_PATH = "https://image.tmdb.org/t/p/w780"
+    private const val YOUTUBE_VIDEO_URL = "https://www.youtube.com/watch?v="
+    private const val YOUTUBE_THUMBNAIL_URL = "https://img.youtube.com/vi/"
 
     fun getPosterPath(posterPath: String): String {
         return BASE_POSTER_PATH + posterPath


### PR DESCRIPTION
This PR fixes the "Cleartext HTTP traffic not permitted" on Android P: https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted

Actually 2 fixes are available:
 * continue using HTTP APIs and allowing cleartext traffic in Andorid Manifest with:
```xml
android:usesCleartextTraffic="true"
``` 
 * Switch to HTTPS APIs.
```kotlin
    private const val BASE_POSTER_PATH = "https://image.tmdb.org/t/p/w342"
    private const val BASE_BACKDROP_PATH = "https://image.tmdb.org/t/p/w780"
    private const val YOUTUBE_VIDEO_URL = "https://www.youtube.com/watch?v="
    private const val YOUTUBE_THUMBNAIL_URL = "https://img.youtube.com/vi/"
```

This PR implements the second option.

Please review and merge.